### PR TITLE
Making winston a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "keywords": ["logging", "winston", "email"],
   "dependencies": {
-    "nodemailer": "*",
+    "nodemailer": "*"
+  },
+  "peerDependencies": {
     "winston"   : "*"
   },
   "main": "./lib/index.js"


### PR DESCRIPTION
In this PR I'm moving winston to be a [peer dependency](http://blog.nodejs.org/2013/02/07/peer-dependencies/). On that way, winston-email uses the winston exact same version installed at the same level. @pgherveou: If you are ok with this change, can you release a new version to npm with this change?

Thanks in advance!
